### PR TITLE
replace CURL by Symfony\Component\HttpClient\HttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Types of changes
     Security in case of vulnerabilities.
 )
 
+## [1.5.3](https://github.com/pdir/contao-theme-helper-bundle/tree/1.5.2) – 2023-03-15
+
+- [Fixed] curl_init error by replacing CURL with Symfony\Component\HttpClient\HttpClient
+
 ## [1.5.2](https://github.com/pdir/contao-theme-helper-bundle/tree/1.5.2) – 2022-09-30
 
 - [Fixed] Optimize domain check

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,17 @@
   },
   "require": {
     "php": "^8.0",
-    "contao/core-bundle": "^5.0"
+    "contao/core-bundle": "^5.0",
+    "symfony/http-client": "^5.4"
   },
   "conflict": {
     "contao/core": "*"
+  },
+  "require-dev": {
+    "contao/manager-plugin": "^2.0",
+    "contao/easy-coding-standard": "^3.0",
+    "phpunit/phpunit": "^7.1 || ^8.4 || ^9.5",
+    "symfony/phpunit-bridge": "^4.4 || ^5.1"
   },
   "autoload": {
     "psr-4": {
@@ -32,5 +39,13 @@
   },
   "extra": {
     "contao-manager-plugin": "Pdir\\ThemeHelperBundle\\ContaoManager\\Plugin"
+  },
+  "config": {
+    "allow-plugins": {
+      "contao-components/installer": true,
+      "php-http/discovery": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "contao/manager-plugin": true
+    }
   }
 }

--- a/contao/config/config.php
+++ b/contao/config/config.php
@@ -30,11 +30,6 @@ $GLOBALS['BE_MOD']['contaoThemesNet']['thLicence'] = [
 ];
 
 /**
- * Register hooks
- */
-$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = ['theme_helper.listener.insert_tags', 'onReplaceInsertTags'];
-
-/**
  * Javascript for Backend
  */
 if (System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest(System::getContainer()->get('request_stack')->getCurrentRequest() ?? Request::create('')))

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+
+$date = date('Y');
+
+$GLOBALS['ecsHeader'] = <<<EOF
+theme helper bundle for Contao Open Source CMS
+
+Copyright (C) $date pdir / digital agentur <develop@pdir.de>
+
+@package    pdir/contao-theme-helper-bundle
+@link       https://github.com/pdir/contao-theme-helper-bundle
+@license    LGPL-3.0+
+@author     pdir GmbH <develop@pdir.de>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOF;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__.'/vendor/contao/easy-coding-standard/config/set/contao.php');
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::LINE_ENDING, "\n");
+
+    $services = $containerConfigurator->services();
+    $services
+        ->set(HeaderCommentFixer::class)
+        ->call('configure', [[
+            'header' => $GLOBALS['ecsHeader'],
+        ]])
+    ;
+};

--- a/src/Backend/Licence.php
+++ b/src/Backend/Licence.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-/**
- * Theme Helper Bundle for Contao Open Source CMS
+/*
+ * theme components bundle for Contao Open Source CMS
  *
- * Copyright (C) 2022 pdir GmbH // pdir / digital agentur <https://pdir.de>
+ * Copyright (C) 2023 pdir / digital agentur <develop@pdir.de>
  *
- * @package    pdir/contao-theme-helper-bundle
- * @link       https://github.com/pdir/contao-theme-helper-bundle
+ * @package    contao-themes-net/theme-components-bundle
+ * @link       https://github.com/contao-themes-net/theme-components-bundle
  * @license    LGPL-3.0+
- * @author     Mathias Arzberger <develop@pdir.de>
+ * @author     pdir GmbH <develop@pdir.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -21,24 +21,25 @@ namespace Pdir\ThemeHelperBundle\Backend;
 use Contao\BackendModule;
 use Contao\Environment;
 use Contao\Input;
-use Contao\ThemeModel;
 use Contao\System;
+use Contao\ThemeModel;
+use Symfony\Component\HttpClient\HttpClient;
 
 class Licence extends BackendModule
 {
     protected $strTemplate = 'be_th_check_domain';
 
     /**
-     * Generate the module
+     * Generate the module.
      */
-    protected function compile()
+    protected function compile(): void
     {
         $this->Template->explanation = $GLOBALS['TL_LANG']['MSC']['th_explanation'];
         $this->Template->domainLabel = $GLOBALS['TL_LANG']['MSC']['th_insert_domain'];
         $this->Template->domainTip = $GLOBALS['TL_LANG']['MSC']['th_domain_tip'];
         $this->Template->buttonCheck = $GLOBALS['TL_LANG']['MSC']['th_button_check'];
-        $this->Template->shortCode = Input::get('shortCode') ? : Input::post('shortCode');
-        $this->Template->theme = Input::get('theme') ? : Input::post('theme');;
+        $this->Template->shortCode = Input::get('shortCode') ?: Input::post('shortCode');
+        $this->Template->theme = Input::get('theme') ?: Input::post('theme');
         $this->Template->message = null;
         $this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
         $this->Template->reloadPage = false;
@@ -46,61 +47,58 @@ class Licence extends BackendModule
         switch (Input::get('act')) {
             case 'checkDomain':
                 // make request to pdir api
-                $url = 'https://pdir.de/api/themes?';
 
-                $params = [
+                $options = [
+                    'base_uri' => 'https://pdir.de/api/',
+                    'headers' => [
+                        'Accept' => 'application/json',
+                        'Content-Type' => 'application/json',
+                    ],
+                ];
+
+                $queryParams = [
                     'domain' => Input::post('domain'),
                     'ip' => Environment::get('server'),
                 ];
 
-                $url .= \http_build_query($params);
+                $url = 'themes?';
 
-                error_reporting(E_ALL);
-                ini_set('display_errors','1');
+                $client = HttpClient::create($options);
 
-                $ch = \curl_init($url);
-                \curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept:application/json, Content-Type:application/json']);
-                \curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
-                \curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                \curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+                // engage
+                $response = $client->request('GET', $url, ['query' => $queryParams]);
+                // gets the HTTP status code of the response
+                $statusCode = $response->getStatusCode();
 
-                $result = \curl_exec($ch);
-                $errNo = \curl_errno($ch);
-                $err = \curl_error($ch);
-                \curl_close($ch);
-
-                if (0 !== $errNo) {
-                    $this->Template->message = $err . " [Error No $errNo]";
+                if (200 !== $statusCode) {
+                    $this->Template->message = $statusCode." [HTTP Status $statusCode]";
                     break;
                 }
 
-                // response
-                $response = \json_decode($result, true);
+                // get response as json
+                $content = $response->toArray();
 
-                if(isset($response['message']) && Input::post('theme'))
-                {
+                if (isset($content['message']) && Input::post('theme')) {
                     // Domain is registered
-                    if($response['message'] == 'Domain registered' && $response['domain'])
-                    {
+                    if ('Domain registered' === $content['message'] && $content['domain']) {
                         /** @var ThemeModel $objTheme */
                         $objTheme = ThemeModel::findById(Input::post('theme'));
-                        $objTheme->pdir_th_license_domain = $response['domain'];
+                        $objTheme->pdir_th_license_domain = $content['domain'];
                         $objTheme->save();
 
                         $this->Template->reloadPage = true;
                     }
 
-                    $this->Template->message = $response['message'];
+                    $this->Template->message = $content['message'];
                     break;
                 }
 
                 break;
+
             default:
-                if(!Input::get('shortCode'))
-                {
+                if (!Input::get('shortCode')) {
                     $this->Template->readonly = true;
                 }
-
         }
     }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-/**
- * Theme Helper Bundle for Contao Open Source CMS
+/*
+ * theme components bundle for Contao Open Source CMS
  *
- * Copyright (C) 2022 pdir GmbH / pdir / digital agentur <develop@pdir.de>
+ * Copyright (C) 2023 pdir / digital agentur <develop@pdir.de>
  *
- * @package    pdir/contao-theme-helper-bundle
- * @link       https://github.com/pdir/contao-theme-helper-bundle
+ * @package    contao-themes-net/theme-components-bundle
+ * @link       https://github.com/contao-themes-net/theme-components-bundle
  * @license    LGPL-3.0+
- * @author     Mathias Arzberger <develop@pdir.de>
+ * @author     pdir GmbH <develop@pdir.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,11 +18,11 @@ declare(strict_types=1);
 
 namespace Pdir\ThemeHelperBundle\ContaoManager;
 
-use Pdir\ThemeHelperBundle\ThemeHelperBundle;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
-use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
+use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Pdir\ThemeHelperBundle\ThemeHelperBundle;
 
 /**
  * Plugin for the Contao Manager.

--- a/src/DependencyInjection/ThemeHelperExtension.php
+++ b/src/DependencyInjection/ThemeHelperExtension.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-/**
- * Theme Helper Bundle for Contao Open Source CMS
+/*
+ * theme components bundle for Contao Open Source CMS
  *
- * Copyright (C) 2022 pdir GmbH / pdir / digital agentur <develop@pdir.de>
+ * Copyright (C) 2023 pdir / digital agentur <develop@pdir.de>
  *
- * @package    pdir/contao-theme-helper-bundle
- * @link       https://github.com/pdir/contao-theme-helper-bundle
+ * @package    contao-themes-net/theme-components-bundle
+ * @link       https://github.com/contao-themes-net/theme-components-bundle
  * @license    LGPL-3.0+
- * @author     Mathias Arzberger <develop@pdir.de>
+ * @author     pdir GmbH <develop@pdir.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -22,6 +22,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
 /**
  * Adds the bundle services to the container.
  *
@@ -32,7 +33,7 @@ class ThemeHelperExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $mergedConfig, ContainerBuilder $container)
+    public function load(array $mergedConfig, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader(
             $container,

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-/**
- * Theme Helper Bundle for Contao Open Source CMS
+/*
+ * theme components bundle for Contao Open Source CMS
  *
- * Copyright (C) 2022 pdir GmbH / pdir / digital agentur <develop@pdir.de>
+ * Copyright (C) 2023 pdir / digital agentur <develop@pdir.de>
  *
- * @package    pdir/contao-theme-helper-bundle
- * @link       https://github.com/pdir/contao-theme-helper-bundle
+ * @package    contao-themes-net/theme-components-bundle
+ * @link       https://github.com/contao-themes-net/theme-components-bundle
  * @license    LGPL-3.0+
- * @author     Mathias Arzberger <develop@pdir.de>
+ * @author     pdir GmbH <develop@pdir.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -21,13 +21,13 @@ namespace Pdir\ThemeHelperBundle\EventListener;
 use Contao\ArticleModel;
 use Contao\ContentElement;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\Events;
-use Contao\StringUtil;
+use Contao\CoreBundle\ServiceAnnotation\Hook;
 
 /**
  * Handles insert tags for themes.
  *
  * @Hook("replaceInsertTags")
+ *
  * @author     Mathias Arzberger <develop@pdir.de>
  */
 class InsertTagsListener
@@ -46,32 +46,24 @@ class InsertTagsListener
 
     /**
      * Constructor.
-     *
-     * @param ContaoFramework $framework
      */
     public function __construct(ContaoFramework $framework)
     {
         $this->framework = $framework;
     }
 
-    public function __invoke(
-        string $insertTag,
-        bool $useCache,
-        string $cachedValue,
-        array $flags,
-        array $tags,
-        array $cache,
-        int $_rit,
-        int $_cnt
-    )
+    public function __invoke(string $insertTag, bool $useCache, string $cachedValue, array $flags, array $tags, array $cache, int $_rit, int $_cnt)
     {
-        $elements = \explode('::', $insertTag);
-        $key = \strtolower($elements[0]);
+        $elements = explode('::', $insertTag);
+        $key = strtolower($elements[0]);
+
         if (\in_array($key, $this->supportedTags, true)) {
             return $this->replaceThemeInsertTag($elements[1], $elements[2]);
         }
+
         return false;
     }
+
     /**
      * Replaces an event-related insert tag.
      *
@@ -85,33 +77,34 @@ class InsertTagsListener
         $rootPageId = $GLOBALS['objPage']->trail[0];
 
         $this->framework->initialize();
+
         switch ($tagType) {
             // get article content by theme helper tag
             case 'content':
                 /** @var ArticleModel $adapter */
                 $adapter = $this->framework->getAdapter(ArticleModel::class);
                 //echo $themeTag."<br>"; echo $rootPageTitle."<br>";
-                if (null === ($article = $adapter->findOneBy( ['tl_article.pdir_th_tag=?','tl_article.pdir_th_domain=?'] , [$themeTag,$rootPageId] ))) {
+                if (null === ($article = $adapter->findOneBy(['tl_article.pdir_th_tag=?', 'tl_article.pdir_th_domain=?'], [$themeTag, $rootPageId]))) {
                     if (null === ($article = $adapter->findOneBy('pdir_th_tag', $themeTag))) {
                         return '';
                     }
                 }
+
                 return $this->generateArticleReplacement($article);
-                break;
         }
+
         return false;
     }
+
     /**
      * Generates the article replacement string.
-     *
-     * @param ArticleModel $article
      *
      * @return string
      */
     private function generateArticleReplacement(ArticleModel $article)
     {
-        /** @var Article $adapter */
         $adapter = $this->framework->getAdapter(ContentElement::class);
+
         return $adapter->getArticle($article);
     }
 }

--- a/src/ThemeHelperBundle.php
+++ b/src/ThemeHelperBundle.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-/**
- * pdir theme helper bundle for Contao Open Source CMS
+/*
+ * theme components bundle for Contao Open Source CMS
  *
- * Copyright (C) 2022 pdir GmbH / pdir / digital agentur <develop@pdir.de>
+ * Copyright (C) 2023 pdir / digital agentur <develop@pdir.de>
  *
- * @package    pdir/contao-theme-helper-bundle
- * @link       https://github.com/pdir/contao-theme-helper-bundle
+ * @package    contao-themes-net/theme-components-bundle
+ * @link       https://github.com/contao-themes-net/theme-components-bundle
  * @license    LGPL-3.0+
- * @author     Mathias Arzberger <develop@pdir.de>
+ * @author     pdir GmbH <develop@pdir.de>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace Pdir\ThemeHelperBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+
 /**
  * Configures the ThemeHelper bundle.
  *


### PR DESCRIPTION
This PR replaces the CURL with Symfony\Component\HttpClient\HttpClient to avoid exceptions on servers where CURL is disabled or not installed.